### PR TITLE
Revert "Use new unordered list item prefix"

### DIFF
--- a/services/user-feeds/src/article-formatter/article-formatter.service.spec.ts
+++ b/services/user-feeds/src/article-formatter/article-formatter.service.spec.ts
@@ -393,16 +393,6 @@ Centro comercial Moctezuma   Francisco Chang   Mexico
       });
     });
 
-    describe("unordered list", () => {
-      it("overrides the prefix", async () => {
-        const result = service.formatValueForDiscord(
-          "<ul><li>1</li><li>2</li></ul>"
-        );
-
-        expect(result.value).toEqual("• 1\n• 2");
-      });
-    });
-
     it("works", async () => {
       const val = `
     <table>

--- a/services/user-feeds/src/article-formatter/article-formatter.service.ts
+++ b/services/user-feeds/src/article-formatter/article-formatter.service.ts
@@ -130,13 +130,6 @@ export class ArticleFormatterService {
       },
     };
 
-    const unorderedListSelector: SelectorDefinition = {
-      selector: "ul",
-      options: {
-        itemPrefix: "• ",
-      },
-    };
-
     const htmlToTextOptions: HtmlToTextOptions = {
       wordwrap: false,
       formatters: {
@@ -210,7 +203,6 @@ export class ArticleFormatterService {
         emSelector,
         uSelector,
         anchorSelector,
-        unorderedListSelector,
       ],
     };
 


### PR DESCRIPTION
This reverts commit 91549d54b11ca97d28520fbabf6b2c850cd4b2a6.

The change was originally done due to [my suggestion in Apr 8](https://github.com/synzen/MonitoRSS/issues/327#issuecomment-1500941574), but shortly after that (surprisingly, [less than two weeks](https://twitter.com/discord/status/1648377300776370205)), Discord added support for markdown lists, so now it's better to use the simple asterisk version again.