### PR TITLE
Remove leading space from unordered list item prefix

### DIFF
--- a/services/user-feeds/src/article-formatter/article-formatter.service.spec.ts
+++ b/services/user-feeds/src/article-formatter/article-formatter.service.spec.ts
@@ -393,6 +393,16 @@ Centro comercial Moctezuma   Francisco Chang   Mexico
       });
     });
 
+    describe("unordered list", () => {
+      it("overrides the prefix", async () => {
+        const result = service.formatValueForDiscord(
+          "<ul><li>1</li><li>2</li></ul>"
+        );
+
+        expect(result.value).toEqual("* 1\n* 2");
+      });
+    });
+
     it("works", async () => {
       const val = `
     <table>

--- a/services/user-feeds/src/article-formatter/article-formatter.service.ts
+++ b/services/user-feeds/src/article-formatter/article-formatter.service.ts
@@ -130,6 +130,13 @@ export class ArticleFormatterService {
       },
     };
 
+    const unorderedListSelector: SelectorDefinition = {
+      selector: "ul",
+      options: {
+        itemPrefix: "* ",
+      },
+    };
+
     const htmlToTextOptions: HtmlToTextOptions = {
       wordwrap: false,
       formatters: {
@@ -203,6 +210,7 @@ export class ArticleFormatterService {
         emSelector,
         uSelector,
         anchorSelector,
+        unorderedListSelector,
       ],
     };
 


### PR DESCRIPTION
Yet another fix for bullets. After my previous PR, the bullets prefix was reverted to the default value [`' * '`](https://github.com/html-to-text/node-html-to-text/blob/5c7a2b2b66d5eea7c1e5b6cd80c5e2d17e119912/packages/html-to-text/README.md?plain=1#L237), and Discord treated it as sub-bullet.

Here's how it looks:
```html
<ul><li>one</li><li>two</li></ul>
```

Turns into:
```markdown
 * one
 * two
```

And is shown as:
![image](https://github.com/synzen/MonitoRSS/assets/4129781/8a920403-1d64-433e-93c4-63e230e2f03f)
