### PR TITLE
fix: embed description limit from 2048 to 4096

### DIFF
--- a/services/user-feeds/src/delivery/mediums/discord-medium.service.ts
+++ b/services/user-feeds/src/delivery/mediums/discord-medium.service.ts
@@ -950,7 +950,7 @@ export class DiscordMediumService implements DeliveryMedium {
             replacePlaceholderStringArgs
           ),
           {
-            limit: 2048,
+            limit: 4096,
           }
         )[0];
 


### PR DESCRIPTION
As per https://discordjs.guide/popular-topics/embeds.html#notes
> Embed descriptions are limited to 4096 characters
