### PR TITLE
Add limit size for docker json logs

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -4,14 +4,14 @@ services:
     image: redis:7.0.7-alpine
     restart: always
     command: redis-server --save 60 1
-    volumes: 
+    volumes:
       - feed-requests-redis-data:/data
     networks:
       - monitorss-default
-  
+
   rabbitmq-broker:
     image: rabbitmq:3-management-alpine
-    container_name: 'rabbitmq-broker'
+    container_name: "rabbitmq-broker"
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 5s
@@ -30,7 +30,7 @@ services:
       - "mongodb-data:/data/db"
     networks:
       - monitorss-default
-  
+
   feed-requests-postgres-db:
     restart: always
     healthcheck:
@@ -50,11 +50,11 @@ services:
       - ./services/feed-requests/sql/setup.sql:/docker-entrypoint-initdb.d/setup.sql
     networks:
       - monitorss-default
-      
+
   user-feeds-postgres-db:
     restart: always
     healthcheck:
-      test: ['CMD', 'pg_isready', '-q', '-d', 'postgres', '-U', 'postgres']
+      test: ["CMD", "pg_isready", "-q", "-d", "postgres", "-U", "postgres"]
       timeout: 45s
       interval: 10s
       retries: 10
@@ -211,9 +211,13 @@ services:
       - USER_FEEDS_API_KEY=user-feeds-api-key
       - USER_FEEDS_REDIS_URI=redis://feed-requests-redis-cache:6379
       - USER_FEEDS_REDIS_DISABLE_CLUSTER=true
+    logging:
+      # driver: "json-file"
+      options:
+        max-size: "${DOCKER_LOGS_MAX_SIZE:-1024m}"
     networks:
       - monitorss-default
-  
+
   user-feeds-postgres-migration:
     restart: on-failure:5
     build:
@@ -238,7 +242,7 @@ services:
       - USER_FEEDS_REDIS_DISABLE_CLUSTER=true
     networks:
       - monitorss-default
-  
+
   # Schedule emitter
   schedule-emitter-service:
     build:


### PR DESCRIPTION
Due some reasons, I make changes in docker compose for me, anyway, choose to share this setting if you want.

1. Logs max size **should** be defined globaly in `daemon.json` (docker), anyway, I make this one changes.
2. I make only for this one service, because only this one stole my 80 GB of space storage.
![image](https://github.com/synzen/MonitoRSS/assets/25010528/c1fdc3a0-108c-4524-b4fb-9b48ddc3e05d)
3. I make `DOCKER_LOGS_MAX_SIZE` env, so if anyone want, he could set custom value (like 512m or etc), default is 1000m
4. I saw, what I break `'` and it `"` now, idk how it happen, feel free to tell me if I should change it back to `'`
5. Tested locally, but better to test again, just for sure.