### PR TITLE
[Security] CVE Patch

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,6 +1,6 @@
 services:
   feed-requests-redis-cache:
-    image: redis:7.0.7-alpine
+    image: redis:7.4.2
     restart: always
     command: redis-server --save 60 1
     volumes:
@@ -24,7 +24,7 @@ services:
     command: mongod --port 27017
     logging:
       driver: none
-    image: mongo:7.0.2
+    image: mongo:8.0.5
     volumes:
       - "mongodb-data:/data/db"
     networks:
@@ -43,7 +43,7 @@ services:
     # Comment below to show logs
     logging:
       driver: none
-    image: postgres:16.3-alpine
+    image: postgres:16.8-alpine
     volumes:
       - feed-requests-postgres16-data:/var/lib/postgresql/data
       - ./services/feed-requests/sql/setup.sql:/docker-entrypoint-initdb.d/setup.sql
@@ -63,7 +63,7 @@ services:
     # Comment below to show logs
     logging:
       driver: none
-    image: postgres:16.3-alpine
+    image: postgres:16.8-alpine
     volumes:
       - user-feeds-postgres16-data:/var/lib/postgresql/data
       - ./services/user-feeds/sql/setup.sql:/docker-entrypoint-initdb.d/setup.sql


### PR DESCRIPTION
This is just patch to avoid known CVE issued by redis,mongo and postgres which mainly RCE.

Those version be tested over week on our production enviroment and not cause any harm with current implement in use.

=Ref=
[redis](https://redis.io/blog/security-advisory-cve-2024-46981-cve-2024-51737-cve-2024-51480-cve-2024-55656/)
[mongo](https://www.mongodb.com/resources/products/mongodb-security-bulletins)
[postgres](https://www.postgresql.org/support/security/)

=Note=
RabbitMQ also better to get patched to newer but it would require some code edit which more likely going to take times so I left as it is this time.