### PR TITLE
Fix leaked feed request listener locks

### DIFF
--- a/services/feed-requests/src/feed-fetcher/feed-fetcher-listener.service.ts
+++ b/services/feed-requests/src/feed-fetcher/feed-fetcher-listener.service.ts
@@ -147,30 +147,30 @@ export class FeedFetcherListenerService {
               return;
             }
 
-            const recentlyProcessed =
-              await this.partitionedRequestsStoreService.wasRequestedInPastSeconds(
-                lookupKey || url,
-                Math.round(rateSeconds * 0.5),
-              );
-
-            if (recentlyProcessed) {
-              contextLogger.info(
-                `Request with key ${
-                  lookupKey || url
-                } with rate ${rateSeconds} was recently processed, skipping`,
-              );
-
-              fetchCompletedToEmit.push({
-                lookupKey,
-                url,
-                rateSeconds,
-                debug: saveToObjectStorage,
-              });
-
-              return;
-            }
-
             try {
+              const recentlyProcessed =
+                await this.partitionedRequestsStoreService.wasRequestedInPastSeconds(
+                  lookupKey || url,
+                  Math.round(rateSeconds * 0.5),
+                );
+
+              if (recentlyProcessed) {
+                contextLogger.info(
+                  `Request with key ${
+                    lookupKey || url
+                  } with rate ${rateSeconds} was recently processed, skipping`,
+                );
+
+                fetchCompletedToEmit.push({
+                  lookupKey,
+                  url,
+                  rateSeconds,
+                  debug: saveToObjectStorage,
+                });
+
+                return;
+              }
+
               await retryUntilTrue(
                 async () => {
                   const { isRateLimited } =
@@ -245,9 +245,7 @@ export class FeedFetcherListenerService {
                 );
               }
 
-              await this.cacheStorageService.del(
-                this.calculateCurrentlyProcessingCacheKeyForMessage(message),
-              );
+              await this.cacheStorageService.del(cacheKey);
             }
           });
         }),

--- a/services/feed-requests/src/feed-fetcher/feed-fetcher-listener.service.unit.spec.ts
+++ b/services/feed-requests/src/feed-fetcher/feed-fetcher-listener.service.unit.spec.ts
@@ -1,8 +1,14 @@
 import { ConfigService } from '@nestjs/config';
-import nock from 'nock';
-import { Request, Response } from './entities';
-import { EntityRepository } from '@mikro-orm/postgresql';
 import { MikroORM } from '@mikro-orm/core';
+// Polyfill for Jest VM environment (redis v4 depends on undici which needs these)
+import { ReadableStream, WritableStream, TransformStream } from 'stream/web';
+
+Object.assign(globalThis, {
+  ReadableStream,
+  WritableStream,
+  TransformStream,
+});
+
 import { FeedFetcherListenerService } from './feed-fetcher-listener.service';
 
 jest.mock('../utils/logger');
@@ -10,27 +16,44 @@ jest.mock('../utils/logger');
 describe('FeedFetcherListenerService', () => {
   let service: FeedFetcherListenerService;
   let configService: ConfigService;
+  let mockMikroOrm: MikroORM;
+  let feedFetcherService: { fetchAndSaveResponse: jest.Mock };
+  let em: { flush: jest.Mock };
+  let partitionedRequestsStoreService: {
+    flushInserts: jest.Mock;
+    wasRequestedInPastSeconds: jest.Mock;
+  };
+  let hostRateLimiterService: { incrementUrlCount: jest.Mock };
+  let cacheStorageService: { setNX: jest.Mock; del: jest.Mock };
   const feedUrl = 'https://rss-feed.com/feed.xml';
   const defaultUserAgent = 'default-user-agent';
-  const requestRepo: EntityRepository<Request> = {
-    persistAndFlush: jest.fn(),
-    persist: jest.fn(),
-    findOne: jest.fn(),
-  } as never;
-  const responseRepo: EntityRepository<Response> = {
-    persistAndFlush: jest.fn(),
-    persist: jest.fn(),
-  } as never;
   const amqpConnection = {
     publish: jest.fn(),
   };
 
   beforeEach(async () => {
     configService = {
-      get: jest.fn(),
-      getOrThrow: jest.fn(),
+      get: jest.fn().mockReturnValue(3),
+      getOrThrow: jest.fn().mockReturnValue(defaultUserAgent),
     } as never;
-    const mockMikroOrm = await MikroORM.init(
+    feedFetcherService = {
+      fetchAndSaveResponse: jest.fn(),
+    };
+    em = {
+      flush: jest.fn().mockResolvedValue(undefined),
+    };
+    partitionedRequestsStoreService = {
+      flushInserts: jest.fn().mockResolvedValue(undefined),
+      wasRequestedInPastSeconds: jest.fn(),
+    };
+    hostRateLimiterService = {
+      incrementUrlCount: jest.fn().mockResolvedValue({ isRateLimited: false }),
+    };
+    cacheStorageService = {
+      setNX: jest.fn(),
+      del: jest.fn().mockResolvedValue(undefined),
+    };
+    mockMikroOrm = await MikroORM.init(
       {
         // Get past errors related to @UseRequestContext() decorator from MikroORM
         type: 'postgresql',
@@ -44,18 +67,18 @@ describe('FeedFetcherListenerService', () => {
     );
 
     service = new FeedFetcherListenerService(
-      requestRepo,
-      responseRepo,
       configService,
-      {} as never,
+      feedFetcherService as never,
       amqpConnection as never,
       mockMikroOrm,
+      em as never,
+      partitionedRequestsStoreService as never,
+      hostRateLimiterService as never,
+      cacheStorageService as never,
     );
-    service.defaultUserAgent = defaultUserAgent;
   });
 
   afterEach(() => {
-    nock.cleanAll();
     jest.resetAllMocks();
   });
 
@@ -68,6 +91,48 @@ describe('FeedFetcherListenerService', () => {
       service.emitFailedUrl({ url: feedUrl });
 
       expect(amqpConnection.publish).toHaveBeenCalled();
+    });
+  });
+
+  describe('onBrokerFetchRequestBatchHandler', () => {
+    const batchRequest = {
+      timestamp: Date.now(),
+      data: [{ url: feedUrl }],
+      rateSeconds: 1800,
+    };
+
+    const runHandler = async () => {
+      await (
+        service as unknown as {
+          onBrokerFetchRequestBatchHandler: (
+            batchRequest: unknown,
+          ) => Promise<void>;
+        }
+      ).onBrokerFetchRequestBatchHandler(batchRequest);
+    };
+
+    it('does not delete the processing lock if this worker did not acquire it', async () => {
+      cacheStorageService.setNX.mockResolvedValue(false);
+
+      await runHandler();
+
+      expect(
+        partitionedRequestsStoreService.wasRequestedInPastSeconds,
+      ).not.toHaveBeenCalled();
+      expect(cacheStorageService.del).not.toHaveBeenCalled();
+    });
+
+    it('deletes the processing lock when a request was recently processed', async () => {
+      cacheStorageService.setNX.mockResolvedValue(true);
+      partitionedRequestsStoreService.wasRequestedInPastSeconds.mockResolvedValue(
+        true,
+      );
+
+      await runHandler();
+
+      expect(cacheStorageService.del).toHaveBeenCalledWith(
+        `listener-service-${feedUrl}`,
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes a scheduled feed delivery wedge where `feed-requests` can leave `listener-service-*` Redis locks behind after a skipped batch item.

Observed on a self-hosted v6 -> v7.2.0 migration: feeds/channels/filters imported, UI test messages worked, UI logs showed feeds updating and articles that would deliver, but scheduled Discord posts stopped. `feed-requests` repeatedly logged `was recently processed, skipping` followed by `is already being processed, skipping`; deleting `feed-requests:listener-service-*` Redis keys restored delivery.

Cause: the `recentlyProcessed` early return happens after this worker acquires the lock but before the existing `finally` that deletes it. This moves that branch inside the cleanup `try/finally`, while preserving the `!wasSet` path so workers do not delete locks they did not acquire.

Validation:
- `npm test -- feed-fetcher-listener.service.unit.spec.ts --runInBand`
- `npm run lint -- --quiet`
- `npm run build`